### PR TITLE
Upgrade node js version in dockerfile, support docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:21
 
 # Set direktori kerja
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,5 @@
+services:
+  app:
+    build: .
+    ports:
+      - "5000:5000"


### PR DESCRIPTION
1. Fixed error outdated Node JS when building Dockerfile (upgrade to Node 21)
2. Added support for docker compose (build: `docker compose up --build` run: `docker compose up -d`)